### PR TITLE
Bridirks patch 5

### DIFF
--- a/ccte-api/chemical/chemical-detail/chemical-detail-validation.feature
+++ b/ccte-api/chemical/chemical-detail/chemical-detail-validation.feature
@@ -13,4 +13,4 @@ Feature: Feature file for validating the response of chemical details resource
     And request batchdtxsid
     When method POST
     Then status 200
-    And match $ contains {"expocatMedianPrediction": "5.50E-05", "expocat": "Y", "nhanes": "Y", "inchikey": "IISBACLAFKSPIT-UHFFFAOYSA-N", "msReadySmiles": "CC(C)(C1=CC=C(O)C=C1)C1=CC=C(O)C=C1", "dtxsid": "DTXSID7020182", "dtxcid": "DTXCID30182", "casrn": "80-05-7", "preferredName": "Bisphenol A", "activeAssays": 221, "molFormula": "C15H16O2", "monoisotopicMass": 228.115029755, "percentAssays": 23.0, "sourcesCount": 113, "totalAssays": 951, "smiles": "CC(C)(C1=CC=C(O)C=C1)C1=CC=C(O)C=C1", "cpdataCount": 292}
+    And match response[0] == {expocatMedianPrediction: '#present', expocat: '#present', nhanes: '#present', inchikey: '#present', msReadySmiles: '#present', dtxsid: '#present', dtxcid: '#present', casrn: '#present', preferredName: '#present', activeAssays: '#present', molFormula: '#present', monoisotopicMass: '#present', percentAssays: '#present', sourcesCount: '#present', totalAssays: '#present', smiles: '#present', cpdataCount: '#present'}

--- a/ccte-api/chemical/chemical-list/chemical-list-validation.feature
+++ b/ccte-api/chemical/chemical-list/chemical-list-validation.feature
@@ -11,46 +11,46 @@ Feature: Feature file for chemical list resource
     Given path '/chemical/list/type'
     When method GET
     Then status 200
-    And match $ == ["federal","international","other","state"]
+    And match response == ["federal","international","other","state"]
 
   Scenario: Validating the response of the GET method for attributes of public lists of type "other"
     Given path '/chemical/list/search/by-type/other'
     And param projection = 'chemicallistall'
     When method GET
     Then status 200
-    And match $ contains {id: #ignore, type: #ignore, label: #ignore, visibility: #ignore, longDescription: #ignore, chemicalCount: #ignore, createdAt: #ignore, updatedAt: #ignore, listName: #ignore, shortDescription: #ignore}
+    And match response[0] == {id: '#present', type: '#present', label: '#present', visibility: '#present', longDescription: '#present', chemicalCount: '#present', createdAt: '#present', updatedAt: '#present', listName: '#present', shortDescription: '#present'}
 
   Scenario: Validating the response of the GET method for the list name attribute of public lists of type "other"
     Given path '/chemical/list/search/by-type/other'
     And param projection = 'chemicallistname'
     When method GET
     Then status 200
-    And match $ contains {listName: #ignore}
+    And match response[0] == {listName: '#present'}
 
   Scenario: Validating the response of the GET method for attributes of public lists of type "other"
     Given path '/chemical/list/search/by-type/other'
     And param projection = 'chemicallistwithdtxsids'
     When method GET
     Then status 200
-    And match $ contains {id: #ignore, type: #ignore, label: #ignore, visibility: #ignore, longDescription: #ignore, dtxsids: #ignore, chemicalCount: #ignore, createdAt: #ignore, updatedAt: #ignore, listName: #ignore, shortDescription: #ignore}
+    And match response[0] == {id: '#present', type: '#present', label: '#present', visibility: '#present', longDescription: '#present', dtxsids: '#present', chemicalCount: '#present', createdAt: '#present', updatedAt: '#present', listName: '#present', shortDescription: '#present'}
 
   Scenario: Validating the response of the GET method for attributes of public lists by name "ACSREAG"
     Given path '/chemical/list/search/by-name/ACSREAG'
     And param projection = 'chemicallistall'
     When method GET
     Then status 200
-    And match $ contains {id: #ignore, type: #ignore, label: #ignore, visibility: #ignore, longDescription: #ignore, chemicalCount: #ignore, createdAt: #ignore, updatedAt: #ignore, listName: #ignore, shortDescription: #ignore}
+    And match response == {id: '#present', type: '#present', label: '#present', visibility: '#present', longDescription: '#present', chemicalCount: '#present', createdAt: '#present', updatedAt: '#present', listName: '#present', shortDescription: '#present'}
 
   Scenario: Validating the response of the GET method for the list name attribute in public lists by name "ACSREAG"
     Given path '/chemical/list/search/by-name/ACSREAG'
     And param projection = 'chemicallistname'
     When method GET
     Then status 200
-    And match $ == {listName: #ignore}
+    And match response == {listName: '#present'}
 
   Scenario: validating the response of the GET method for attributes of public lists by name "ACSREAG"
     Given path '/chemical/list/search/by-name/ACSREAG'
     And param projection = 'chemicallistwithdtxsids'
     When method GET
     Then status 200
-    And match $ == {id: #ignore, type: #ignore, label: #ignore, visibility: #ignore, longDescription: #ignore, dtxsids: #ignore, chemicalCount: #ignore, createdAt: #ignore, updatedAt: #ignore, listName: #ignore, shortDescription: #ignore}
+    And match response == {id: '#present', type: '#present', label: '#present', visibility: '#present', longDescription: '#present', dtxsids: '#present', chemicalCount: '#present', createdAt: '#present', updatedAt: '#present', listName: '#present', shortDescription: '#present'}

--- a/ccte-api/chemical/chemical-search/chemical-search-validation.feature
+++ b/ccte-api/chemical/chemical-search/chemical-search-validation.feature
@@ -10,17 +10,16 @@ Feature: Feature file for validating chemical search resource
     Given path '/chemical/search/start-with/atraz'
     When method GET
     Then status 200
-    And match $ contains{hasStructureImage : #ignore, smiles : #ignore, isMarkush :#ignore, searchName : #ignore, searchValue : #ignore, rank : #ignore, dtxsid : #ignore, dtxcid : #ignore, casrn : #ignore, preferredName : #ignore}
+    And match response[0] == {hasStructureImage : '#present', smiles : '#present', isMarkush :'#present', searchName : '#present', searchValue : '#present', rank : '#present', dtxsid : '#present', dtxcid : '#present', casrn : '#present', preferredName : '#present'}
 
   Scenario: Validating response attributes using the GET method for chemical search by exact match of chemical name
     Given path '/chemical/search/equal/atrazine'
     When method GET
     Then status 200
-    And match $ contains {hasStructureImage : #ignore, smiles : #ignore, isMarkush : #ignore, searchName : #ignore, searchValue : #ignore, rank : #ignore, dtxsid : #ignore, dtxcid : #ignore, casrn : #ignore, preferredName : #ignore}
+    And match response[0] == {hasStructureImage : '#present', smiles : '#present', isMarkush : '#present', searchName : '#present', searchValue : '#present', rank : '#present', dtxsid : '#present', dtxcid : '#present', casrn : '#present', preferredName : '#present'}
 
   Scenario: Validating response attributes using the GET method for chemical search by substring of chemical name
     Given path '/chemical/search/contain/razine'
     When method GET
     Then status 200
-    And match $ contains {hasStructureImage: #ignore, smiles: #ignore, isMarkush: #ignore, searchName: #ignore, searchValue: #ignore, rank: #ignore, dtxsid: #ignore, dtxcid: #ignore, casrn: #ignore, preferredName: #ignore}
-
+    And match response[0] == {hasStructureImage: '#present', smiles: '#present', isMarkush: '#present', searchName: '#present', searchValue: '#present', rank: '#present', dtxsid: '#present', dtxcid: '#present', casrn: '#present', preferredName: '#present'}

--- a/ccte-api/chemical/chemical-synonym/chemical-synonym-validation.feature
+++ b/ccte-api/chemical/chemical-synonym/chemical-synonym-validation.feature
@@ -1,5 +1,5 @@
 @regression
-Feature: Feature file for validating chemical synonym
+Feature: Feature file for chemical synonym
 
   Background:
     * url ccte
@@ -11,4 +11,4 @@ Feature: Feature file for validating chemical synonym
     Given path '/chemical/synonym/search/by-dtxsid/DTXSID7020182'
     When method GET
     Then status 200
-    And match $ contains {pcCode: #ignore , other: #ignore , beilstein: #ignore , alternateCasrn: #ignore , valid: #ignore , good: #ignore , deletedCasrn: #ignore , dtxsid: #ignore}
+    And match response == {pcCode: '#present', other: '#present', beilstein: '#present', alternateCasrn: '#present', valid: '#present', good: '#present', deletedCasrn: '#present', dtxsid: '#present'}


### PR DESCRIPTION
Removed data specific matching for everything except chemical-msready. Ignore has been changed to Present to validate presence of variable (Fix)